### PR TITLE
Made use love.handlers.

### DIFF
--- a/scenery.lua
+++ b/scenery.lua
@@ -135,10 +135,10 @@ function Scenery.init(...)
     end
     
     -- All the callbacks available in Love 11.4 as described on https://love2d.org/wiki/Category:Callbacks
-    local loveCallbacks = { "draw", "update" } -- Execpt these three.
+    local loveCallbacks = { "load", "draw", "update" } -- Except these three.
     for k in pairs(love.handlers) do
         table.insert(loveCallbacks, k)
-	end
+    end
 
     -- Loop through the callbacks creating a function with same name on the base class
     for _, value in ipairs(loveCallbacks) do

--- a/scenery.lua
+++ b/scenery.lua
@@ -135,7 +135,7 @@ function Scenery.init(...)
     end
     
     -- All the callbacks available in Love 11.4 as described on https://love2d.org/wiki/Category:Callbacks
-    local loveCallbacks = { "load", "draw", "update" } -- Execpt these three.
+    local loveCallbacks = { "draw", "update" } -- Execpt these three.
     for k in pairs(love.handlers) do
         table.insert(loveCallbacks, k)
 	end


### PR DESCRIPTION
Enchanted and working version of: https://github.com/gphg/scenery/commit/c77bb2d04697b27370ca27a8e6abfb15a335811b

* Utilize `love.handlers`. Not listed and not re-added callbacks are:  `errhand`, `errorhandler`.

* Added `Scenary:hook`, which inject all scene callbacks into targeted table: `love`. Keep your `main.lua` clean.

* `setScene` is now not a global function. It can be accessed via `self.setScene`.