### PR TITLE
Pass multiple instead single arguments on `load`.

### DIFF
--- a/scenery.lua
+++ b/scenery.lua
@@ -121,11 +121,11 @@ function Scenery.init(...)
     end
 
     -- This function is available for all scene.
-    function this.setScene(key, data)
+    function this.setScene(key, ...)
         assert(this.scenes[key], "No such scene '" .. key .. "'")
         this.currentscene = key
         if this.scenes[this.currentscene].load then
-            this.scenes[this.currentscene]:load(data)
+            this.scenes[this.currentscene]:load(...)
         end
     end
 


### PR DESCRIPTION
It is odd when the rest of handler allow multiple, but this one is not. Basically, it is possible to do something like this: `Test.setScene('Pause', 'resume', 'Game Paused')`. Normally, I have to pass a table.