### PR TITLE
Have automatic loading detect directories with an init file as scenes

### DIFF
--- a/examples/Auto-loading with Custom Folder/scenery.lua
+++ b/examples/Auto-loading with Custom Folder/scenery.lua
@@ -44,7 +44,19 @@ local autoLoad = function(directory)
         local file, ext = split(value, ".")
 
         -- Require scene
-        if ext == "lua" and file ~= "conf" and file ~= "main" then
+        if ext == file then
+            local info = love.filesystem.getInfo(directory .. "/" .. file)
+
+            -- Check if item is a directory
+            if info and (info.type == "directory" or info.type == "symlink") then
+                info = love.filesystem.getInfo(directory .. "/" .. file .. "/init.lua")
+
+                -- Check for the init file
+                if info and info.type == "file" then
+                    scenes[file] = require(directory .. "." .. file)
+                end
+            end
+        elseif ext == "lua" and file ~= "conf" and file ~= "main" then
             scenes[file] = require(directory .. "." .. file)
         end
     end

--- a/examples/Automatic Loading/scenery.lua
+++ b/examples/Automatic Loading/scenery.lua
@@ -44,7 +44,19 @@ local autoLoad = function(directory)
         local file, ext = split(value, ".")
 
         -- Require scene
-        if ext == "lua" and file ~= "conf" and file ~= "main" then
+        if ext == file then
+            local info = love.filesystem.getInfo(directory .. "/" .. file)
+
+            -- Check if item is a directory
+            if info and (info.type == "directory" or info.type == "symlink") then
+                info = love.filesystem.getInfo(directory .. "/" .. file .. "/init.lua")
+
+                -- Check for the init file
+                if info and info.type == "file" then
+                    scenes[file] = require(directory .. "." .. file)
+                end
+            end
+        elseif ext == "lua" and file ~= "conf" and file ~= "main" then
             scenes[file] = require(directory .. "." .. file)
         end
     end

--- a/examples/Manual Loading/scenery.lua
+++ b/examples/Manual Loading/scenery.lua
@@ -44,7 +44,19 @@ local autoLoad = function(directory)
         local file, ext = split(value, ".")
 
         -- Require scene
-        if ext == "lua" and file ~= "conf" and file ~= "main" then
+        if ext == file then
+            local info = love.filesystem.getInfo(directory .. "/" .. file)
+
+            -- Check if item is a directory
+            if info and (info.type == "directory" or info.type == "symlink") then
+                info = love.filesystem.getInfo(directory .. "/" .. file .. "/init.lua")
+
+                -- Check for the init file
+                if info and info.type == "file" then
+                    scenes[file] = require(directory .. "." .. file)
+                end
+            end
+        elseif ext == "lua" and file ~= "conf" and file ~= "main" then
             scenes[file] = require(directory .. "." .. file)
         end
     end

--- a/scenery.lua
+++ b/scenery.lua
@@ -44,7 +44,19 @@ local autoLoad = function(directory)
         local file, ext = split(value, ".")
 
         -- Require scene
-        if ext == "lua" and file ~= "conf" and file ~= "main" then
+        if ext == file then
+            local info = love.filesystem.getInfo(directory .. "/" .. file)
+
+            -- Check if item is a directory
+            if info and (info.type == "directory" or info.type == "symlink") then
+                info = love.filesystem.getInfo(directory .. "/" .. file .. "/init.lua")
+
+                -- Check for the init file
+                if info and info.type == "file" then
+                    scenes[file] = require(directory .. "." .. file)
+                end
+            end
+        elseif ext == "lua" and file ~= "conf" and file ~= "main" then
             scenes[file] = require(directory .. "." .. file)
         end
     end


### PR DESCRIPTION
One of the paths that `require` can check for is a directory with the module's name containing an `init.lua` file. I added an additional check in the automatic scene loading so these are detected. (It already works when using manual loading.) I added this for my own use; I wanted to group all of the content of a given scene in one directory.